### PR TITLE
Added feature to automatically set correct KSUMMA-value when writing SIE files.

### DIFF
--- a/jsiSIE/jsiSIE/SieDocument.cs
+++ b/jsiSIE/jsiSIE/SieDocument.cs
@@ -185,6 +185,21 @@ namespace jsiSIE
         {
             _fileName = fileName;
 
+            using (var stream = new FileStream(_fileName, FileMode.Open))
+            {
+                ReadStreamAux(stream);
+            }
+        }
+
+        public void ReadDocument(Stream stream)
+        {
+            _fileName = "(stream)";
+            ReadStreamAux(stream);
+        }
+        
+        private void ReadStreamAux(Stream stream)
+        {
+            
             if (ThrowErrors) Callbacks.SieException += throwCallbackException;
 
             #region Initialize lists
@@ -209,11 +224,27 @@ namespace jsiSIE
             InitializeDimensions();
             #endregion //Initialize listst
 
-            SieVoucher curVoucher = null;
-
-            bool firstLine = true;
-            foreach (var line in File.ReadLines(_fileName, Encoding.GetEncoding(437)))
+            using (var sr = new StreamReader(stream, Encoding.GetEncoding(437)))
             {
+                if (parseLines(sr)) return;
+            }
+
+            validateDocument();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="sr"></param>
+        /// <returns>true if start of file is valid SIE-format</returns>
+        private bool parseLines(StreamReader sr)
+        {
+            bool firstLine = true;
+            SieVoucher curVoucher = null;
+            do
+            {
+                var line = sr.ReadLine();
+
                 Callbacks.CallbackLine(line);
                 var di = new SieDataItem(line, this);
 
@@ -223,7 +254,7 @@ namespace jsiSIE
                     if (di.ItemType != "#FLAGGA")
                     {
                         Callbacks.CallbackException(new SieInvalidFileException(_fileName));
-                        return;
+                        return true;
                     }
                 }
 
@@ -245,7 +276,7 @@ namespace jsiSIE
                         break;
 
                     case "#BTRANS":
-                        if(!IgnoreBTRANS) parseTRANS(di, curVoucher);
+                        if (!IgnoreBTRANS) parseTRANS(di, curVoucher);
                         break;
 
                     case "#DIM":
@@ -297,6 +328,7 @@ namespace jsiSIE
                         {
                             CRC.Start();
                         }
+
                         break;
                     case "#KTYP":
                         parseKTYP(di);
@@ -337,6 +369,7 @@ namespace jsiSIE
                             Callbacks.CallbackPBUDGET(pv);
                             if (!StreamValues) PBUDGET.Add(pv);
                         }
+
                         break;
 
                     case "#PROGRAM":
@@ -354,6 +387,7 @@ namespace jsiSIE
                             Callbacks.CallbackPSALDO(pv);
                             if (!StreamValues) PSALDO.Add(pv);
                         }
+
                         break;
 
                     case "#RAR":
@@ -408,10 +442,11 @@ namespace jsiSIE
                         Callbacks.CallbackException(new NotImplementedException(di.ItemType));
                         break;
                 }
-            }
+            } while (!sr.EndOfStream);
 
-            validateDocument();
+            return false;
         }
+
 
         private void parseRAR(SieDataItem di)
         {


### PR DESCRIPTION
I've made a non-breaking change to SieDocumentWriter method signature which looks like this:
`public SieDocumentWriter(SieDocument sie, WriteOptions options = null)`

The constructor now takes an optional WriteOptions parameter which currently contains a single option WriteKSUMMA a boolean that iff true will lead to the KSUMMA-flag be written. 

When writing the KSUMMA flag the write operation first writes the document with a faulty KSUMMA checksum value to a temporary MemoryStream, reads that into a temporary SieDocument variable using a new overload of the public SieDocument.ReadDocument-method which takes a Stream instead of the filepath string, this is done in order to get the expected KSUMMA checksum value which is used by SieDocument-class to verify KSUMMA. Finally this expected value is set on the original SieDocument.KSUMMA variable and is used in a second pass of write operation which writes to the intented FileStream. Because I've added an overload to the SieDocument.ReadDocument I've also refactored some of the code in the class to keep it DRY.