### PR TITLE
Print object identities within quotes in objektlist

### DIFF
--- a/jsiSIE/jsiSIE/SieDocumentWriter.cs
+++ b/jsiSIE/jsiSIE/SieDocumentWriter.cs
@@ -182,10 +182,11 @@ namespace jsiSIE
 
                 foreach (var o in d.Objects.Values)
                 {
-                    WriteLine("#OBJEKT " + d.Number + " " + o.Number + " \"" + o.Name + "\"");
+                    WriteLine("#OBJEKT " + d.Number + " \"" + o.Number + "\" \"" + o.Name + "\"");
                 }
             }
         }
+
         private void WriteUNDERDIM()
         {
             if (_sie.UNDERDIM == null) return;
@@ -195,7 +196,7 @@ namespace jsiSIE
 
                 foreach (var o in d.Objects.Values)
                 {
-                    WriteLine("#OBJEKT " + d.Number + " " + o.Number + " \"" + o.Name + "\"");
+                    WriteLine("#OBJEKT " + d.Number + " \"" + o.Number + "\" \"" + o.Name + "\"");
                 }
             }
         }

--- a/jsiSIE/jsiSIE/SieDocumentWriter.cs
+++ b/jsiSIE/jsiSIE/SieDocumentWriter.cs
@@ -221,7 +221,14 @@ namespace jsiSIE
             foreach (var v in list)
             {
                 var objekt = getObjeklista(v.Objects);
-                WriteLine(name + " " + v.YearNr.ToString() + " " + v.Period.ToString() + " " + v.Account.Number + " " + objekt + " " + SieAmount(v.Amount));
+
+                var quantity = "";
+                if (v.Quantity.HasValue)
+                {
+                    quantity = SieAmount(v.Quantity.Value);
+                }
+
+                WriteLine(name + " " + v.YearNr.ToString() + " " + v.Period.ToString() + " " + v.Account.Number + " " + objekt + " " + SieAmount(v.Amount) + " " + quantity);
             }
         }
 


### PR DESCRIPTION
### Citattecken runt objektid vid deklaration av OBJEKT

**Motiv:** Är inte säkert numeriskt. I ett textbaserat kan mellanslag förekomma. Blir också konsekvent med hur objektid:n skrivs i i andra taggar. Stämmer också väl med de exempel som finns i SIE-specen. Därför blir smidigast hantering är att alltid omsluta objektid:n med citattecken då det är ok enligt spec.