### PR TITLE
Writer: Remove Carriage Return return in SieText.

### DIFF
--- a/jsiSIE/jsiSIE/SieDocumentWriter.cs
+++ b/jsiSIE/jsiSIE/SieDocumentWriter.cs
@@ -283,7 +283,7 @@ namespace jsiSIE
 
         private string SieText(string input)
         {
-            return input?.Replace("\"", "\\\"");
+            return input?.Replace("\"", "\\\"").Replace("\r", "");
         }
 
         private void WriteKONTO()


### PR DESCRIPTION
Lagrad vagnretur (CR) i text blir och också en radbrytning i filen. Vår erfarenhet är att kunderna gillar att klippa och klistra och då är det tyvärr rätt vanligt att en vagnretur följer med och sparas i databasen. I vårt nya system, så städas dylikt bort med automatik, så det aldrig hamnar i databasen, men blir för stort att lösa i vårt gamla. Därför adderade jag borttag av vagnretur i SieText.

/Leif

Ps. Kommer en separat Pull request med ParsingLineNumber. Den var nödvändig och väldigt bra för att hitta denna typ av problem i stor fil. Ds.