### PR TITLE
Reader: DIM handling according to standard.

### DIFF
--- a/jsiSIE/jsiSIE/SieDocument.cs
+++ b/jsiSIE/jsiSIE/SieDocument.cs
@@ -19,6 +19,13 @@ namespace jsiSIE
         public bool IgnoreMissingOMFATTNING = false;
         public bool IgnoreRTRANS = false;
         public bool IgnoreMissingDate = true;
+
+        /// <summary>
+        /// True - allow TEMPDIMs to exist after reading file except for SIETYP 3.
+        /// DIM declaration is only mandatory for type 3.
+        /// </summary>
+        public bool IgnoreMissingDIM = false;
+
         public bool AllowMissingDate { get => IgnoreMissingDate; set => IgnoreMissingDate = value; }
         public bool AllowUnbalancedVoucher { get;  set; }
 
@@ -916,10 +923,12 @@ namespace jsiSIE
                     new SieInvalidChecksumException(_fileName));
             }
 
-            // All TEMPDIMs should have been resolved when read is completed.
-            addValidationException(TEMPDIM.Any(),
-                new SieMissingMandatoryDateException("#DIM or #UNDERDIM is missing for one or more objects in " + _fileName));
-
+            if (!IgnoreMissingDIM || SIETYP == 3)
+            {
+                // All TEMPDIMs should have been resolved when read is completed.
+                addValidationException(TEMPDIM.Any(),
+                    new SieMissingMandatoryDateException("#DIM or #UNDERDIM is missing for one or more objects in " + _fileName));
+            }
         }
 
         public SieBookingYear rar { get; set; }


### PR DESCRIPTION
Det är bara krav på att deklarera DIM för typ 3. Med denna lösning, så fungerar det per default likadant som det gjorde innan, men det är nu möjligt att läsa in en fil där dimensionsnr förekommer transaktioner och saldon utan att de för den skull är deklarerade.

Av egen erfarenhet vet jag att det finns många varianter som DIM hanteras av de som gör filer. T.ex. att några är deklarerade och helt andra förekommer i transaktioner.

/Leif